### PR TITLE
feat: Add inline markdown support to markdown tables and wraptext ins…

### DIFF
--- a/.github/workflows/community-report.yml
+++ b/.github/workflows/community-report.yml
@@ -1,0 +1,188 @@
+name: Generate Weekly Community Report 📊
+
+on:
+  schedule:
+    - cron: '0 12 * * 1' # Run at 12:00 UTC on Monday
+  workflow_dispatch:
+    inputs:
+      days:
+        description: 'Number of days to look back for the report'
+        required: true
+        default: '7'
+
+jobs:
+  generate-report:
+    name: Generate Report 📝
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: read
+      discussions: read
+      contents: read
+      id-token: write
+
+    steps:
+      - name: Generate GitHub App Token 🔑
+        id: generate_token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.PRIVATE_KEY }}
+
+      - name: Generate Report 📜
+        id: report
+        env:
+          GH_TOKEN: ${{ steps.generate_token.outputs.token }}
+          REPO: ${{ github.repository }}
+          DAYS: ${{ github.event.inputs.days || '7' }}
+        run: |
+          set -e
+
+          START_DATE=$(date -u -d "$DAYS days ago" +'%Y-%m-%d')
+          END_DATE=$(date -u +'%Y-%m-%d')
+          echo "⏳ Generating report for contributions from $START_DATE to $END_DATE..."
+
+          declare -A author_is_googler
+          check_googler_status() {
+              local author=$1
+              if [[ "$author" == *"[bot]" ]]; then
+                  author_is_googler[$author]=1
+                  return 1
+              fi
+              if [[ -v "author_is_googler[$author]" ]]; then
+                  return ${author_is_googler[$author]}
+              fi
+
+              if gh api "orgs/googlers/members/$author" --silent 2>/dev/null; then
+                  echo "🧑‍💻 $author is a Googler."
+                  author_is_googler[$author]=0
+              else
+                  echo "🌍 $author is a community contributor."
+                  author_is_googler[$author]=1
+              fi
+              return ${author_is_googler[$author]}
+          }
+
+          googler_issues=0
+          non_googler_issues=0
+          googler_prs=0
+          non_googler_prs=0
+
+          echo "🔎 Fetching issues and pull requests..."
+          ITEMS_JSON=$(gh search issues --repo "$REPO" "created:>$START_DATE" --json author,isPullRequest --limit 1000)
+
+          for row in $(echo "${ITEMS_JSON}" | jq -r '.[] | @base64'); do
+              _jq() {
+                  echo ${row} | base64 --decode | jq -r ${1}
+              }
+              author=$(_jq '.author.login')
+              is_pr=$(_jq '.isPullRequest')
+
+              if [[ -z "$author" || "$author" == "null" ]]; then
+                continue
+              fi
+
+              if check_googler_status "$author"; then
+                  if [[ "$is_pr" == "true" ]]; then
+                      ((googler_prs++))
+                  else
+                      ((googler_issues++))
+                  fi
+              else
+                  if [[ "$is_pr" == "true" ]]; then
+                      ((non_googler_prs++))
+                  else
+                      ((non_googler_issues++))
+                  fi
+              fi
+          done
+
+          googler_discussions=0
+          non_googler_discussions=0
+
+          echo "🗣️ Fetching discussions..."
+          DISCUSSION_QUERY='''
+          query($q: String!) {
+            search(query: $q, type: DISCUSSION, first: 100) {
+              nodes {
+                ... on Discussion {
+                  author {
+                    login
+                  }
+                }
+              }
+            }
+          }'''
+          DISCUSSIONS_JSON=$(gh api graphql -f q="repo:$REPO created:>$START_DATE" -f query="$DISCUSSION_QUERY")
+
+          for row in $(echo "${DISCUSSIONS_JSON}" | jq -r '.data.search.nodes[] | @base64'); do
+              _jq() {
+                  echo ${row} | base64 --decode | jq -r ${1}
+              }
+              author=$(_jq '.author.login')
+
+              if [[ -z "$author" || "$author" == "null" ]]; then
+                continue
+              fi
+
+              if check_googler_status "$author"; then
+                  ((googler_discussions++))
+              else
+                  ((non_googler_discussions++))
+              fi
+          done
+
+          echo "✍️ Generating report content..."
+          REPORT_TITLE="Community Contribution Report: $START_DATE to $END_DATE"
+          TOTAL_ISSUES=$((googler_issues + non_googler_issues))
+          TOTAL_PRS=$((googler_prs + non_googler_prs))
+          TOTAL_DISCUSSIONS=$((googler_discussions + non_googler_discussions))
+
+          REPORT_BODY=$(cat <<EOF
+          ### 💖 Community Contribution Report
+
+          **Period:** $START_DATE to $END_DATE
+
+          | Category | Googlers | Community | Total |
+          |---|---:|---:|---:|
+          | **Issues** | $googler_issues | $non_googler_issues | **$TOTAL_ISSUES** |
+          | **Pull Requests** | $googler_prs | $non_googler_prs | **$TOTAL_PRS** |
+          | **Discussions** | $googler_discussions | $non_googler_discussions | **$TOTAL_DISCUSSIONS** |
+
+          _This report was generated automatically by a GitHub Action._
+          EOF
+          )
+
+          echo "report_body<<EOF" >> $GITHUB_OUTPUT
+          echo "$REPORT_BODY" >> $GITHUB_OUTPUT
+          echo "EOF" >> $GITHUB_OUTPUT
+
+          echo "📊 Community Contribution Report:"
+          echo "$REPORT_BODY"
+
+      - name: 🤖 Get Insights from Report
+        if: steps.report.outputs.report_body != ''
+        uses: google-gemini/gemini-cli-action@41c0f1b3cbd1a0b284251bd1aac034edd07a3a2f
+        env:
+          GITHUB_TOKEN: ${{ steps.generate_token.outputs.token }}
+        with:
+          version: 0.1.8-rc.0
+          GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
+          OTLP_GCP_WIF_PROVIDER: ${{ secrets.OTLP_GCP_WIF_PROVIDER }}
+          OTLP_GCP_SERVICE_ACCOUNT: ${{ secrets.OTLP_GCP_SERVICE_ACCOUNT }}
+          OTLP_GOOGLE_CLOUD_PROJECT: ${{ secrets.OTLP_GOOGLE_CLOUD_PROJECT }}
+          settings_json: |
+            {
+              "coreTools": [
+                "run_shell_command(gh issue list)",
+                "run_shell_command(gh pr list)",
+                "run_shell_command(gh search issues)",
+                "run_shell_command(gh search prs)"
+              ]
+            }
+          prompt: |
+            You are a helpful assistant that analyzes community contribution reports.
+            Based on the following report, please provide a brief summary and highlight any interesting trends or potential areas for improvement.
+
+            Report:
+            ${{ steps.report.outputs.report_body }}

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -10,7 +10,6 @@
   },
   "scripts": {
     "build": "node ../../scripts/build_package.js",
-    "clean": "rm -rf dist",
     "start": "node dist/index.js",
     "debug": "node --inspect-brk dist/index.js",
     "lint": "eslint . --ext .ts,.tsx",

--- a/packages/cli/src/ui/components/shared/MaxSizedBox.tsx
+++ b/packages/cli/src/ui/components/shared/MaxSizedBox.tsx
@@ -278,7 +278,10 @@ function visitBoxRow(element: React.ReactNode): Row {
       // Allow the key prop, which is automatically added by React.
       maxExpectedProps += 1;
     }
-    if (boxProps.flexDirection !== 'row') {
+    if (
+      boxProps.flexDirection !== undefined &&
+      boxProps.flexDirection !== 'row'
+    ) {
       debugReportError(
         'MaxSizedBox children must have flexDirection="row".',
         element,

--- a/packages/cli/src/ui/utils/InlineRenderer.tsx
+++ b/packages/cli/src/ui/utils/InlineRenderer.tsx
@@ -1,0 +1,154 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import React from 'react';
+import { Text } from 'ink';
+import { Colors } from '../colors.js';
+
+// Constants for Markdown parsing and rendering
+const BOLD_MARKER_LENGTH = 2; // For "**"
+const ITALIC_MARKER_LENGTH = 1; // For "*" or "_"
+const STRIKETHROUGH_MARKER_LENGTH = 2; // For "~~"
+const INLINE_CODE_MARKER_LENGTH = 1; // For "`"
+const UNDERLINE_TAG_START_LENGTH = 3; // For "<u>"
+const UNDERLINE_TAG_END_LENGTH = 4; // For "</u>"
+
+interface RenderInlineProps {
+  text: string;
+}
+
+const RenderInlineInternal: React.FC<RenderInlineProps> = ({ text }) => {
+  const nodes: React.ReactNode[] = [];
+  let lastIndex = 0;
+  const inlineRegex =
+    /(\*\*.*?\*\*|\*.*?\*|_.*?_|~~.*?~~|\[.*?\]\(.*?\)|`+.+?`+|<u>.*?<\/u>)/g;
+  let match;
+
+  while ((match = inlineRegex.exec(text)) !== null) {
+    if (match.index > lastIndex) {
+      nodes.push(
+        <Text key={`t-${lastIndex}`}>
+          {text.slice(lastIndex, match.index)}
+        </Text>,
+      );
+    }
+
+    const fullMatch = match[0];
+    let renderedNode: React.ReactNode = null;
+    const key = `m-${match.index}`;
+
+    try {
+      if (
+        fullMatch.startsWith('**') &&
+        fullMatch.endsWith('**') &&
+        fullMatch.length > BOLD_MARKER_LENGTH * 2
+      ) {
+        renderedNode = (
+          <Text key={key} bold>
+            {fullMatch.slice(BOLD_MARKER_LENGTH, -BOLD_MARKER_LENGTH)}
+          </Text>
+        );
+      } else if (
+        fullMatch.length > ITALIC_MARKER_LENGTH * 2 &&
+        ((fullMatch.startsWith('*') && fullMatch.endsWith('*')) ||
+          (fullMatch.startsWith('_') && fullMatch.endsWith('_'))) &&
+        !/\w/.test(text.substring(match.index - 1, match.index)) &&
+        !/\w/.test(
+          text.substring(inlineRegex.lastIndex, inlineRegex.lastIndex + 1),
+        ) &&
+        !/\S[./\\]/.test(text.substring(match.index - 2, match.index)) &&
+        !/[./\\]\S/.test(
+          text.substring(inlineRegex.lastIndex, inlineRegex.lastIndex + 2),
+        )
+      ) {
+        renderedNode = (
+          <Text key={key} italic>
+            {fullMatch.slice(ITALIC_MARKER_LENGTH, -ITALIC_MARKER_LENGTH)}
+          </Text>
+        );
+      } else if (
+        fullMatch.startsWith('~~') &&
+        fullMatch.endsWith('~~') &&
+        fullMatch.length > STRIKETHROUGH_MARKER_LENGTH * 2
+      ) {
+        renderedNode = (
+          <Text key={key} strikethrough>
+            {fullMatch.slice(
+              STRIKETHROUGH_MARKER_LENGTH,
+              -STRIKETHROUGH_MARKER_LENGTH,
+            )}
+          </Text>
+        );
+      } else if (
+        fullMatch.startsWith('`') &&
+        fullMatch.endsWith('`') &&
+        fullMatch.length > INLINE_CODE_MARKER_LENGTH
+      ) {
+        const codeMatch = fullMatch.match(/^(`+)(.+?)\1$/s);
+        if (codeMatch && codeMatch[2]) {
+          renderedNode = (
+            <Text key={key} color={Colors.AccentPurple}>
+              {codeMatch[2]}
+            </Text>
+          );
+        } else {
+          renderedNode = (
+            <Text key={key} color={Colors.AccentPurple}>
+              {fullMatch.slice(
+                INLINE_CODE_MARKER_LENGTH,
+                -INLINE_CODE_MARKER_LENGTH,
+              )}
+            </Text>
+          );
+        }
+      } else if (
+        fullMatch.startsWith('[') &&
+        fullMatch.includes('](') &&
+        fullMatch.endsWith(')')
+      ) {
+        const linkMatch = fullMatch.match(/\[(.*?)\]\((.*?)\)/);
+        if (linkMatch) {
+          const linkText = linkMatch[1];
+          const url = linkMatch[2];
+          renderedNode = (
+            <Text key={key}>
+              {linkText}
+              <Text color={Colors.AccentBlue}> ({url})</Text>
+            </Text>
+          );
+        }
+      } else if (
+        fullMatch.startsWith('<u>') &&
+        fullMatch.endsWith('</u>') &&
+        fullMatch.length >
+          UNDERLINE_TAG_START_LENGTH + UNDERLINE_TAG_END_LENGTH - 1 // -1 because length is compared to combined length of start and end tags
+      ) {
+        renderedNode = (
+          <Text key={key} underline>
+            {fullMatch.slice(
+              UNDERLINE_TAG_START_LENGTH,
+              -UNDERLINE_TAG_END_LENGTH,
+            )}
+          </Text>
+        );
+      }
+    } catch (e) {
+      console.error('Error parsing inline markdown part:', fullMatch, e);
+      renderedNode = null;
+    }
+
+    nodes.push(renderedNode ?? <Text key={key}>{fullMatch}</Text>);
+    lastIndex = inlineRegex.lastIndex;
+  }
+
+  if (lastIndex < text.length) {
+    nodes.push(<Text key={`t-${lastIndex}`}>{text.slice(lastIndex)}</Text>);
+  }
+
+  return <>{nodes.filter((node) => node !== null)}</>;
+};
+
+export const RenderInline = React.memo(RenderInlineInternal);

--- a/packages/cli/src/ui/utils/MarkdownDisplay.test.tsx
+++ b/packages/cli/src/ui/utils/MarkdownDisplay.test.tsx
@@ -278,3 +278,86 @@ console.log(x);
     });
   });
 });
+describe('Table Rendering Styles', () => {
+  it('should render bold markdown inside table cells', () => {
+    const boldTable = `
+  | Col | Desc          |
+  |-----|---------------|
+  | **Foo** | Bar       |
+  `;
+    const { lastFrame } = render(
+      <MarkdownDisplay text={boldTable} isPending={false} terminalWidth={80} />,
+    );
+    const output = lastFrame();
+    // Markdown symbols should not appear in the rendered output
+    expect(output).not.toContain('**Foo**');
+    // The content should be present (without the markdown symbols)
+    expect(output).toContain('Foo');
+    expect(output).toContain('Bar');
+    // Verify table structure is maintained
+    expect(output).toContain('Col');
+    expect(output).toContain('Desc');
+  });
+
+  it('should render italic markdown inside table cells', () => {
+    const italicTable = `
+  | Col | Desc          |
+  |-----|---------------|
+  | *Foo* | Bar        |
+  `;
+    const { lastFrame } = render(
+      <MarkdownDisplay
+        text={italicTable}
+        isPending={false}
+        terminalWidth={80}
+      />,
+    );
+    const output = lastFrame();
+    // Markdown symbols should not appear in the rendered output
+    expect(output).not.toContain('*Foo*');
+    // The content should be present (without the markdown symbols)
+    expect(output).toContain('Foo');
+    expect(output).toContain('Bar');
+    // Verify table structure is maintained
+    expect(output).toContain('Col');
+    expect(output).toContain('Desc');
+  });
+
+  it('should render multiple markdown formats in table cells', () => {
+    const complexTable = `
+  | Format | Example | Notes |
+  |--------|---------|-------|
+  | **Bold** | *Italic* | \`Code\` |
+  | ~~Strike~~ | [Link](url) | <u>Underline</u> |
+  `;
+    const { lastFrame } = render(
+      <MarkdownDisplay
+        text={complexTable}
+        isPending={false}
+        terminalWidth={100}
+      />,
+    );
+    const output = lastFrame();
+
+    // Verify markdown symbols are not visible in output
+    expect(output).not.toContain('**Bold**');
+    expect(output).not.toContain('*Italic*');
+    expect(output).not.toContain('`Code`');
+    expect(output).not.toContain('~~Strike~~');
+    expect(output).not.toContain('[Link](url)');
+    expect(output).not.toContain('<u>Underline</u>');
+
+    // Verify content is present
+    expect(output).toContain('Bold');
+    expect(output).toContain('Italic');
+    expect(output).toContain('Code');
+    expect(output).toContain('Strike');
+    expect(output).toContain('Link');
+    expect(output).toContain('Underline');
+
+    // Verify table headers
+    expect(output).toContain('Format');
+    expect(output).toContain('Example');
+    expect(output).toContain('Notes');
+  });
+});

--- a/packages/cli/src/ui/utils/MarkdownDisplay.tsx
+++ b/packages/cli/src/ui/utils/MarkdownDisplay.tsx
@@ -9,6 +9,7 @@ import { Text, Box } from 'ink';
 import { Colors } from '../colors.js';
 import { colorizeCode } from './CodeColorizer.js';
 import { TableRenderer } from './TableRenderer.js';
+import { RenderInline } from './InlineRenderer.js';
 
 interface MarkdownDisplayProps {
   text: string;
@@ -16,14 +17,6 @@ interface MarkdownDisplayProps {
   availableTerminalHeight?: number;
   terminalWidth: number;
 }
-
-// Constants for Markdown parsing and rendering
-const BOLD_MARKER_LENGTH = 2; // For "**"
-const ITALIC_MARKER_LENGTH = 1; // For "*" or "_"
-const STRIKETHROUGH_MARKER_LENGTH = 2; // For "~~"
-const INLINE_CODE_MARKER_LENGTH = 1; // For "`"
-const UNDERLINE_TAG_START_LENGTH = 3; // For "<u>"
-const UNDERLINE_TAG_END_LENGTH = 4; // For "</u>"
 
 const EMPTY_LINE_HEIGHT = 1;
 const CODE_BLOCK_PADDING = 1;
@@ -276,143 +269,6 @@ const MarkdownDisplayInternal: React.FC<MarkdownDisplayProps> = ({
 };
 
 // Helper functions (adapted from static methods of MarkdownRenderer)
-
-interface RenderInlineProps {
-  text: string;
-}
-
-const RenderInlineInternal: React.FC<RenderInlineProps> = ({ text }) => {
-  const nodes: React.ReactNode[] = [];
-  let lastIndex = 0;
-  const inlineRegex =
-    /(\*\*.*?\*\*|\*.*?\*|_.*?_|~~.*?~~|\[.*?\]\(.*?\)|`+.+?`+|<u>.*?<\/u>)/g;
-  let match;
-
-  while ((match = inlineRegex.exec(text)) !== null) {
-    if (match.index > lastIndex) {
-      nodes.push(
-        <Text key={`t-${lastIndex}`}>
-          {text.slice(lastIndex, match.index)}
-        </Text>,
-      );
-    }
-
-    const fullMatch = match[0];
-    let renderedNode: React.ReactNode = null;
-    const key = `m-${match.index}`;
-
-    try {
-      if (
-        fullMatch.startsWith('**') &&
-        fullMatch.endsWith('**') &&
-        fullMatch.length > BOLD_MARKER_LENGTH * 2
-      ) {
-        renderedNode = (
-          <Text key={key} bold>
-            {fullMatch.slice(BOLD_MARKER_LENGTH, -BOLD_MARKER_LENGTH)}
-          </Text>
-        );
-      } else if (
-        fullMatch.length > ITALIC_MARKER_LENGTH * 2 &&
-        ((fullMatch.startsWith('*') && fullMatch.endsWith('*')) ||
-          (fullMatch.startsWith('_') && fullMatch.endsWith('_'))) &&
-        !/\w/.test(text.substring(match.index - 1, match.index)) &&
-        !/\w/.test(
-          text.substring(inlineRegex.lastIndex, inlineRegex.lastIndex + 1),
-        ) &&
-        !/\S[./\\]/.test(text.substring(match.index - 2, match.index)) &&
-        !/[./\\]\S/.test(
-          text.substring(inlineRegex.lastIndex, inlineRegex.lastIndex + 2),
-        )
-      ) {
-        renderedNode = (
-          <Text key={key} italic>
-            {fullMatch.slice(ITALIC_MARKER_LENGTH, -ITALIC_MARKER_LENGTH)}
-          </Text>
-        );
-      } else if (
-        fullMatch.startsWith('~~') &&
-        fullMatch.endsWith('~~') &&
-        fullMatch.length > STRIKETHROUGH_MARKER_LENGTH * 2
-      ) {
-        renderedNode = (
-          <Text key={key} strikethrough>
-            {fullMatch.slice(
-              STRIKETHROUGH_MARKER_LENGTH,
-              -STRIKETHROUGH_MARKER_LENGTH,
-            )}
-          </Text>
-        );
-      } else if (
-        fullMatch.startsWith('`') &&
-        fullMatch.endsWith('`') &&
-        fullMatch.length > INLINE_CODE_MARKER_LENGTH
-      ) {
-        const codeMatch = fullMatch.match(/^(`+)(.+?)\1$/s);
-        if (codeMatch && codeMatch[2]) {
-          renderedNode = (
-            <Text key={key} color={Colors.AccentPurple}>
-              {codeMatch[2]}
-            </Text>
-          );
-        } else {
-          renderedNode = (
-            <Text key={key} color={Colors.AccentPurple}>
-              {fullMatch.slice(
-                INLINE_CODE_MARKER_LENGTH,
-                -INLINE_CODE_MARKER_LENGTH,
-              )}
-            </Text>
-          );
-        }
-      } else if (
-        fullMatch.startsWith('[') &&
-        fullMatch.includes('](') &&
-        fullMatch.endsWith(')')
-      ) {
-        const linkMatch = fullMatch.match(/\[(.*?)\]\((.*?)\)/);
-        if (linkMatch) {
-          const linkText = linkMatch[1];
-          const url = linkMatch[2];
-          renderedNode = (
-            <Text key={key}>
-              {linkText}
-              <Text color={Colors.AccentBlue}> ({url})</Text>
-            </Text>
-          );
-        }
-      } else if (
-        fullMatch.startsWith('<u>') &&
-        fullMatch.endsWith('</u>') &&
-        fullMatch.length >
-          UNDERLINE_TAG_START_LENGTH + UNDERLINE_TAG_END_LENGTH - 1 // -1 because length is compared to combined length of start and end tags
-      ) {
-        renderedNode = (
-          <Text key={key} underline>
-            {fullMatch.slice(
-              UNDERLINE_TAG_START_LENGTH,
-              -UNDERLINE_TAG_END_LENGTH,
-            )}
-          </Text>
-        );
-      }
-    } catch (e) {
-      console.error('Error parsing inline markdown part:', fullMatch, e);
-      renderedNode = null;
-    }
-
-    nodes.push(renderedNode ?? <Text key={key}>{fullMatch}</Text>);
-    lastIndex = inlineRegex.lastIndex;
-  }
-
-  if (lastIndex < text.length) {
-    nodes.push(<Text key={`t-${lastIndex}`}>{text.slice(lastIndex)}</Text>);
-  }
-
-  return <>{nodes.filter((node) => node !== null)}</>;
-};
-
-const RenderInline = React.memo(RenderInlineInternal);
 
 interface RenderCodeBlockProps {
   content: string[];

--- a/packages/cli/src/ui/utils/TableRenderer.tsx
+++ b/packages/cli/src/ui/utils/TableRenderer.tsx
@@ -7,6 +7,7 @@
 import React from 'react';
 import { Text, Box } from 'ink';
 import { Colors } from '../colors.js';
+import { RenderInline } from './InlineRenderer.js';
 
 interface TableRendererProps {
   headers: string[];
@@ -40,44 +41,83 @@ export const TableRenderer: React.FC<TableRendererProps> = ({
     Math.floor(width * scaleFactor),
   );
 
-  const renderCell = (content: string, width: number, isHeader = false) => {
-    // The actual space for content inside the padding
-    const contentWidth = Math.max(0, width - 2);
+  // Helper function to calculate the wrapped height of text
+  // Here, raw, pre-markdown text is used while InlineRenderer applies the markdown style, removing the markdown syntax. This can lead to small inconsistencies in height calculation. However, it is alright since the length of actual content is usually much larger than the markdown syntax. So the height difference is negligible.
+  const getWrappedHeight = (text: string, width: number): number => {
+    if (width <= 0) return 1;
+    const lines = text.split('\n');
+    let totalLines = 0;
 
-    let cellContent = content;
-    if (content.length > contentWidth) {
-      if (contentWidth <= 3) {
-        // Not enough space for '...'
-        cellContent = content.substring(0, contentWidth);
+    for (const line of lines) {
+      if (line.length === 0) {
+        totalLines += 1;
       } else {
-        cellContent = content.substring(0, contentWidth - 3) + '...';
+        totalLines += Math.ceil(line.length / width);
       }
     }
 
-    // Pad the content to fill the cell
-    const padded = cellContent.padEnd(contentWidth, ' ');
-
-    if (isHeader) {
-      return (
-        <Text bold color={Colors.AccentCyan}>
-          {padded}
-        </Text>
-      );
-    }
-    return <Text>{padded}</Text>;
+    return Math.max(1, totalLines);
   };
 
-  const renderRow = (cells: string[], isHeader = false) => (
-    <Box flexDirection="row">
-      <Text>│ </Text>
-      {cells.map((cell, index) => (
-        <React.Fragment key={index}>
-          {renderCell(cell, adjustedWidths[index] || 0, isHeader)}
-          <Text> │ </Text>
-        </React.Fragment>
-      ))}
-    </Box>
-  );
+  // Helper function to get the height of a row (max height among all cells)
+  const getRowHeight = (cells: string[]): number =>
+    Math.max(
+      ...cells.map((cell, index) => {
+        const contentWidth = Math.max(0, (adjustedWidths[index] || 0) - 2);
+        return getWrappedHeight(cell, contentWidth);
+      }),
+    );
+
+  const renderCell = (
+    content: string,
+    width: number,
+    height: number,
+    isHeader = false,
+  ) => {
+    // The actual space for content inside the padding
+    const contentWidth = Math.max(0, width - 2);
+
+    // Apply inline rendering first
+    const textComponent = isHeader ? (
+      <Text bold color={Colors.AccentCyan}>
+        <RenderInline text={content} />
+      </Text>
+    ) : (
+      <Text>
+        <RenderInline text={content} />
+      </Text>
+    );
+
+    return (
+      <Box width={contentWidth} height={height} flexDirection="column">
+        {textComponent}
+      </Box>
+    );
+  };
+
+  const renderRow = (cells: string[], isHeader = false) => {
+    const rowHeight = getRowHeight(cells);
+
+    return (
+      <Box flexDirection="row" height={rowHeight}>
+        <Box flexDirection="column" justifyContent="space-between">
+          {Array.from({ length: rowHeight }, (_, i) => (
+            <Text key={i}>│ </Text>
+          ))}
+        </Box>
+        {cells.map((cell, index) => (
+          <React.Fragment key={index}>
+            {renderCell(cell, adjustedWidths[index] || 0, rowHeight, isHeader)}
+            <Box flexDirection="column" justifyContent="space-between">
+              {Array.from({ length: rowHeight }, (_, i) => (
+                <Text key={i}> │ </Text>
+              ))}
+            </Box>
+          </React.Fragment>
+        ))}
+      </Box>
+    );
+  };
 
   const renderSeparator = () => {
     const separator = adjustedWidths

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -8,7 +8,6 @@
   "scripts": {
     "start": "node dist/src/index.js",
     "build": "node ../../scripts/build_package.js",
-    "clean": "rm -rf dist",
     "lint": "eslint . --ext .ts,.tsx",
     "format": "prettier --write .",
     "test": "vitest run",


### PR DESCRIPTION
## TLDR

Add inline markdown support to markdown tables and allow content wrapping in table cells as opposed to truncation.

## Dive Deeper

Previously, markdown tags like bold and italics were not being rendered inside markdown tables. **Refactored the `RenderInlineInternal` component from MarkdownDisplay.tsx into its own separate InlineRenderer.tsx module** and integrated the same implementation into the `TableRenderer` component. The previous implementation of `RenderInlineInternal` was moved unchanged into the new module. 

Any improvements to this component `RenderInlineInternal` will be addressed in some other PR and not this one.

Previously, cell content within markdown tables was truncated based on available width. Added support for wrapping of text instead, so information is not lost.


## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅  | ❓  | ❓  |
| npx      | ✅  | ❓  | ❓  |
| Docker   | ✅  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

None
