### PR TITLE
feat: Add Alt+Backspace/Delete shortcuts for word deletion in input p…

### DIFF
--- a/packages/cli/src/ui/components/InputPrompt.tsx
+++ b/packages/cli/src/ui/components/InputPrompt.tsx
@@ -250,6 +250,18 @@ export const InputPrompt: React.FC<InputPromptProps> = ({
         return;
       }
 
+      // Alt+Backspace to delete word before cursor
+      if (key.meta && key.name === 'backspace') {
+        buffer.deleteWordLeft();
+        return;
+      }
+
+      // Alt+Delete to delete word after cursor
+      if (key.meta && key.name === 'delete') {
+        buffer.deleteWordRight();
+        return;
+      }
+
       // Core text editing from MultilineTextEditor's useInput
       if (key.ctrl && key.name === 'k') {
         buffer.killLineRight();


### PR DESCRIPTION
## TLDR

Added Alt+Backspace and Alt+Delete keyboard shortcuts for word-level deletion in the CLI input prompt, matching standard text editor behavior.

## Dive Deeper

Implements two common keyboard shortcuts:
- **Alt+Backspace**: Delete word left of cursor
- **Alt+Delete**: Delete word right of cursor

Uses existing TextBuffer methods `deleteWordLeft()` and `deleteWordRight()`. Improves editing efficiency for longer prompts and file paths.

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅  | ❓  | ❓  |
| npx      | ✅  | ❓  | ❓  |
| Docker   | ✅  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

None. Enhancement