### PR TITLE
Search

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,9 +10,6 @@
       "workspaces": [
         "packages/*"
       ],
-      "dependencies": {
-        "shell-quote": "^1.8.3"
-      },
       "bin": {
         "gemini": "bundle/gemini.js"
       },
@@ -11410,7 +11407,7 @@
         "ignore": "^7.0.0",
         "micromatch": "^4.0.8",
         "open": "^10.1.2",
-        "shell-quote": "^1.8.2",
+        "shell-quote": "^1.8.3",
         "simple-git": "^3.28.0",
         "strip-ansi": "^7.1.0",
         "undici": "^7.10.0",

--- a/packages/cli/src/ui/components/InputPrompt.test.tsx
+++ b/packages/cli/src/ui/components/InputPrompt.test.tsx
@@ -94,6 +94,11 @@ describe('InputPrompt', () => {
       addCommandToHistory: vi.fn(),
       getPreviousCommand: vi.fn().mockReturnValue(null),
       getNextCommand: vi.fn().mockReturnValue(null),
+      getMatchingCommand: vi.fn().mockReturnValue(null),
+      getNextMatchingCommand: vi.fn().mockReturnValue(null),
+      getPreviousMatchingCommand: vi.fn().mockReturnValue(null),
+      resetMatching: vi.fn(),
+
       resetHistoryPosition: vi.fn(),
     };
     mockedUseShellHistory.mockReturnValue(mockShellHistory);
@@ -193,6 +198,40 @@ describe('InputPrompt', () => {
 
     expect(mockShellHistory.addCommandToHistory).toHaveBeenCalledWith('ls -l');
     expect(props.onSubmit).toHaveBeenCalledWith('ls -l');
+    unmount();
+  });
+
+  it('should call reverse search methods on up key when reverse search is active', async () => {
+    props.shellModeActive = true;
+    vi.mocked(mockShellHistory.getPreviousMatchingCommand).mockReturnValue(
+      'ls -l',
+    );
+    const { stdin, unmount } = render(<InputPrompt {...props} />);
+    await wait();
+    // Write Ctrl+R to activate reverse search
+    stdin.write('\u0012'); // Ctrl+R
+    await wait();
+    stdin.write('\u001B[A'); // Up arrow
+    await wait();
+
+    expect(mockShellHistory.getPreviousMatchingCommand).toHaveBeenCalled();
+    expect(props.buffer.setText).toHaveBeenCalledWith('ls -l');
+    unmount();
+  });
+
+  it('should call reverse search methods on down key when reverse search is active', async () => {
+    props.shellModeActive = true;
+    vi.mocked(mockShellHistory.getNextMatchingCommand).mockReturnValue('ls -l');
+    const { stdin, unmount } = render(<InputPrompt {...props} />);
+    await wait();
+    // Write Ctrl+R to activate reverse search
+    stdin.write('\u0012'); // Ctrl+R
+    await wait();
+    stdin.write('\u001B[B'); // Down arrow
+    await wait();
+
+    expect(mockShellHistory.getNextMatchingCommand).toHaveBeenCalled();
+    expect(props.buffer.setText).toHaveBeenCalledWith('ls -l');
     unmount();
   });
 

--- a/packages/cli/src/ui/hooks/useShellHistory.ts
+++ b/packages/cli/src/ui/hooks/useShellHistory.ts
@@ -131,7 +131,7 @@ export function useShellHistory(projectRoot: string) {
   }, [matchingCommands, matchingIndex]);
 
   const getNextMatchingCommand = useCallback((): string | null => {
-    if (matchingCommands.length === 0 || matchingIndex < 0) {
+    if (matchingCommands.length === 0) {
       return null;
     }
     const newIndex = matchingIndex - 1;

--- a/packages/cli/src/ui/hooks/useShellHistory.ts
+++ b/packages/cli/src/ui/hooks/useShellHistory.ts
@@ -46,6 +46,8 @@ export function useShellHistory(projectRoot: string) {
   const [history, setHistory] = useState<string[]>([]);
   const [historyIndex, setHistoryIndex] = useState(-1);
   const [historyFilePath, setHistoryFilePath] = useState<string | null>(null);
+  const [matchingCommands, setMatchingCommands] = useState<string[]>([]);
+  const [matchingIndex, setMatchingIndex] = useState(-1);
 
   useEffect(() => {
     async function loadHistory() {
@@ -94,10 +96,66 @@ export function useShellHistory(projectRoot: string) {
     return history[newIndex] ?? null;
   }, [history, historyIndex]);
 
+  const getMatchingCommand = useCallback(
+    (toMatch: string) => {
+      const query = toMatch.trim();
+      if (!query) {
+        setMatchingCommands([]);
+        setMatchingIndex(-1);
+        return null;
+      }
+
+      const matches = history.filter((cmd) =>
+        cmd.toLowerCase().includes(query.toLowerCase()),
+      );
+
+      setMatchingCommands(matches);
+      if (matches.length > 0) {
+        setMatchingIndex(0);
+        return matches[0];
+      }
+      setMatchingIndex(-1);
+      return null;
+    },
+    [history],
+  );
+
+  const getPreviousMatchingCommand = useCallback((): string | null => {
+    if (matchingCommands.length === 0) return null;
+    const newIndex =
+      matchingIndex < 0
+        ? 0
+        : Math.min(matchingIndex + 1, matchingCommands.length - 1);
+    setMatchingIndex(newIndex);
+    return matchingCommands[newIndex] ?? null;
+  }, [matchingCommands, matchingIndex]);
+
+  const getNextMatchingCommand = useCallback((): string | null => {
+    if (matchingCommands.length === 0 || matchingIndex < 0) {
+      return null;
+    }
+    const newIndex = matchingIndex - 1;
+    setMatchingIndex(newIndex);
+    if (newIndex < 0) {
+      return null;
+    }
+    return matchingCommands[newIndex] ?? null;
+  }, [matchingCommands, matchingIndex]);
+
+  const resetMatching = useCallback(() => {
+    setMatchingCommands([]);
+    setMatchingIndex(-1);
+  }, []);
+
   return {
     addCommandToHistory,
     getPreviousCommand,
     getNextCommand,
+    getMatchingCommand,
+    getPreviousMatchingCommand,
+    getNextMatchingCommand,
+    resetMatching,
+
     resetHistoryPosition: () => setHistoryIndex(-1),
   };
 }


### PR DESCRIPTION
## TLDR

Add reverse search mode in shell mode. Search query now appears in cyan and matched commands in green.

## Dive Deeper
Type `Ctrl+r` to enter reverse string search mode when in shell mode. Use up/down to navigate matches.

## Reviewer Test Plan

1. Enter shell mode with `!`
2. Press `Ctrl+R` to activate reverse search
3. Type some characters - they should appear in cyan
4. If a match is found, the matched portion should appear in green
5. Test backspace removes characters correctly
6. Test `Ctrl+G` exits reverse search mode
7. Test `Enter` accepts the current match

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

#3475