### PR TITLE
Search

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,9 +10,6 @@
       "workspaces": [
         "packages/*"
       ],
-      "dependencies": {
-        "shell-quote": "^1.8.3"
-      },
       "bin": {
         "gemini": "bundle/gemini.js"
       },
@@ -11410,7 +11407,7 @@
         "ignore": "^7.0.0",
         "micromatch": "^4.0.8",
         "open": "^10.1.2",
-        "shell-quote": "^1.8.2",
+        "shell-quote": "^1.8.3",
         "simple-git": "^3.28.0",
         "strip-ansi": "^7.1.0",
         "undici": "^7.10.0",

--- a/packages/cli/src/ui/components/InputPrompt.test.tsx
+++ b/packages/cli/src/ui/components/InputPrompt.test.tsx
@@ -94,6 +94,11 @@ describe('InputPrompt', () => {
       addCommandToHistory: vi.fn(),
       getPreviousCommand: vi.fn().mockReturnValue(null),
       getNextCommand: vi.fn().mockReturnValue(null),
+      getMatchingCommand: vi.fn().mockReturnValue(null),
+      getNextMatchingCommand: vi.fn().mockReturnValue(null),
+      getPreviousMatchingCommand: vi.fn().mockReturnValue(null),
+      resetMatching: vi.fn(),
+
       resetHistoryPosition: vi.fn(),
     };
     mockedUseShellHistory.mockReturnValue(mockShellHistory);
@@ -193,6 +198,40 @@ describe('InputPrompt', () => {
 
     expect(mockShellHistory.addCommandToHistory).toHaveBeenCalledWith('ls -l');
     expect(props.onSubmit).toHaveBeenCalledWith('ls -l');
+    unmount();
+  });
+
+  it('should call reverse search methods on up key when reverse search is active', async () => {
+    props.shellModeActive = true;
+    vi.mocked(mockShellHistory.getPreviousMatchingCommand).mockReturnValue(
+      'ls -l',
+    );
+    const { stdin, unmount } = render(<InputPrompt {...props} />);
+    await wait();
+    // Write Ctrl+R to activate reverse search
+    stdin.write('\u0012'); // Ctrl+R
+    await wait();
+    stdin.write('\u001B[A'); // Up arrow
+    await wait();
+
+    expect(mockShellHistory.getPreviousMatchingCommand).toHaveBeenCalled();
+    expect(props.buffer.setText).toHaveBeenCalledWith('ls -l');
+    unmount();
+  });
+
+  it('should call reverse search methods on down key when reverse search is active', async () => {
+    props.shellModeActive = true;
+    vi.mocked(mockShellHistory.getNextMatchingCommand).mockReturnValue('ls -l');
+    const { stdin, unmount } = render(<InputPrompt {...props} />);
+    await wait();
+    // Write Ctrl+R to activate reverse search
+    stdin.write('\u0012'); // Ctrl+R
+    await wait();
+    stdin.write('\u001B[B'); // Down arrow
+    await wait();
+
+    expect(mockShellHistory.getNextMatchingCommand).toHaveBeenCalled();
+    expect(props.buffer.setText).toHaveBeenCalledWith('ls -l');
     unmount();
   });
 

--- a/packages/cli/src/ui/components/InputPrompt.tsx
+++ b/packages/cli/src/ui/components/InputPrompt.tsx
@@ -324,6 +324,7 @@ export const InputPrompt: React.FC<InputPromptProps> = ({
               const prevMatch = shellHistory.getNextMatchingCommand();
               if (prevMatch !== null) {
                 buffer.setText(prevMatch);
+                !prevMatch || setReverseSearchQuery(''); // Clear query if no match
               }
               return;
             }
@@ -341,11 +342,18 @@ export const InputPrompt: React.FC<InputPromptProps> = ({
             }
 
             if (key.name === 'return') {
+              const command = buffer.text;
+
               setReverseSearchActive(false);
               setReverseSearchQuery('');
-              setOriginalBufferText('');
               shellHistory.resetMatching();
-              handleSubmitAndClear(buffer.text.trim());
+
+              if (command.trim()) {
+                setOriginalBufferText('');
+                handleSubmitAndClear(command);
+              } else {
+                buffer.setText(originalBufferText);
+              }
               return;
             }
 

--- a/packages/cli/src/ui/components/InputPrompt.tsx
+++ b/packages/cli/src/ui/components/InputPrompt.tsx
@@ -20,6 +20,28 @@ import { isAtCommand, isSlashCommand } from '../utils/commandUtils.js';
 import { CommandContext, SlashCommand } from '../commands/types.js';
 import { Config } from '@google/gemini-cli-core';
 
+function getHighlightedReverseSearchText(
+  display: string,
+  bufferText: string,
+  reverseSearchQuery: string,
+): string {
+  const queryLower = reverseSearchQuery.toLowerCase();
+  const textLower = bufferText.toLowerCase();
+  const matchIndex = textLower.indexOf(queryLower);
+
+  if (matchIndex !== -1) {
+    const before = cpSlice(display, 0, matchIndex);
+    const matched = cpSlice(
+      display,
+      matchIndex,
+      matchIndex + reverseSearchQuery.length,
+    );
+    const after = cpSlice(display, matchIndex + reverseSearchQuery.length);
+    return before + chalk.hex(Colors.AccentYellow)(matched) + after;
+  }
+  return chalk.dim(display);
+}
+
 export interface InputPromptProps {
   buffer: TextBuffer;
   onSubmit: (value: string) => void;
@@ -52,6 +74,9 @@ export const InputPrompt: React.FC<InputPromptProps> = ({
   setShellModeActive,
 }) => {
   const [justNavigatedHistory, setJustNavigatedHistory] = useState(false);
+  const [reverseSearchActive, setReverseSearchActive] = useState(false);
+  const [reverseSearchQuery, setReverseSearchQuery] = useState('');
+  const [originalBufferText, setOriginalBufferText] = useState('');
 
   const completion = useCompletion(
     buffer.text,
@@ -195,6 +220,13 @@ export const InputPrompt: React.FC<InputPromptProps> = ({
       }
 
       if (key.name === 'escape') {
+        if (reverseSearchActive) {
+          setReverseSearchActive(false);
+          setReverseSearchQuery('');
+          buffer.setText(originalBufferText);
+          shellHistory.resetMatching();
+        }
+
         if (shellModeActive) {
           setShellModeActive(false);
           return;
@@ -261,7 +293,78 @@ export const InputPrompt: React.FC<InputPromptProps> = ({
             return;
           }
         } else {
-          // Shell History Navigation
+          // Shell History Navigation with reverse search
+          if (key.name === 'r' && key.ctrl && !reverseSearchActive) {
+            setReverseSearchActive(true);
+
+            setOriginalBufferText(buffer.text);
+            buffer.setText(''); // Clear the buffer for reverse search
+            setReverseSearchQuery('');
+            return;
+          }
+
+          if (reverseSearchActive) {
+            if (key.name === 'g' && key.ctrl) {
+              setReverseSearchActive(false);
+              shellHistory.resetMatching();
+              setReverseSearchQuery('');
+              buffer.setText(originalBufferText);
+              return;
+            }
+
+            if (key.name === 'up' || (key.name === 'r' && key.ctrl)) {
+              const nextMatch = shellHistory.getPreviousMatchingCommand();
+              if (nextMatch !== null) {
+                buffer.setText(nextMatch);
+              }
+              return;
+            }
+
+            if (key.name === 'down' || (key.name === 's' && key.ctrl)) {
+              const prevMatch = shellHistory.getNextMatchingCommand();
+              if (prevMatch !== null) {
+                buffer.setText(prevMatch);
+              }
+              return;
+            }
+
+            if (key.name === 'backspace') {
+              const nextQuery = reverseSearchQuery.slice(0, -1);
+              setReverseSearchQuery(nextQuery);
+              const match = shellHistory.getMatchingCommand(nextQuery);
+              if (match) {
+                buffer.setText(match);
+              } else {
+                buffer.setText('');
+              }
+              return;
+            }
+
+            if (key.name === 'return') {
+              setReverseSearchActive(false);
+              setReverseSearchQuery('');
+              setOriginalBufferText('');
+              shellHistory.resetMatching();
+              handleSubmitAndClear(buffer.text.trim());
+              return;
+            }
+
+            if (
+              key.sequence &&
+              key.sequence.length > 0 &&
+              !key.ctrl &&
+              !key.meta
+            ) {
+              const nextQuery = reverseSearchQuery + key.sequence;
+              setReverseSearchQuery(nextQuery);
+              const match = shellHistory.getMatchingCommand(nextQuery);
+              buffer.setText(match || '');
+              return;
+            }
+            return;
+          }
+
+          // Normal shell history navigation
           if (key.name === 'up') {
             const prevCommand = shellHistory.getPreviousCommand();
             if (prevCommand !== null) buffer.setText(prevCommand);
@@ -329,6 +432,12 @@ export const InputPrompt: React.FC<InputPromptProps> = ({
       handleAutocomplete,
       handleSubmitAndClear,
       shellHistory,
+      reverseSearchActive,
+      reverseSearchQuery,
+      setReverseSearchActive,
+      setReverseSearchQuery,
+      originalBufferText,
+      setOriginalBufferText,
     ],
   );
 
@@ -349,7 +458,15 @@ export const InputPrompt: React.FC<InputPromptProps> = ({
         <Text
           color={shellModeActive ? Colors.AccentYellow : Colors.AccentPurple}
         >
-          {shellModeActive ? '! ' : '> '}
+          {shellModeActive ? (
+            reverseSearchActive ? (
+              <Text color={Colors.AccentCyan}>(r): </Text>
+            ) : (
+              '! '
+            )
+          ) : (
+            '> '
+          )}
         </Text>
         <Box flexGrow={1} flexDirection="column">
           {buffer.text.length === 0 && placeholder ? (
@@ -370,7 +487,28 @@ export const InputPrompt: React.FC<InputPromptProps> = ({
                 display = display + ' '.repeat(inputWidth - currentVisualWidth);
               }
 
-              if (visualIdxInRenderedSet === cursorVisualRow) {
+              // Color highlighting for reverse search
+              if (reverseSearchActive && shellModeActive) {
+                if (buffer.text && reverseSearchQuery) {
+                  display = getHighlightedReverseSearchText(
+                    display,
+                    buffer.text,
+                    reverseSearchQuery,
+                  );
+                } else if (reverseSearchQuery) {
+                  // No match found, show just the search query being typed
+                  display = chalk.hex(Colors.AccentGreen)(reverseSearchQuery);
+                } else {
+                  // No search query yet, show empty
+                  display = '';
+                }
+              }
+
+              // Apply cursor highlighting (but not during reverse search)
+              if (
+                visualIdxInRenderedSet === cursorVisualRow &&
+                !reverseSearchActive
+              ) {
                 const relativeVisualColForHighlight = cursorVisualColAbsolute;
                 if (relativeVisualColForHighlight >= 0) {
                   if (relativeVisualColForHighlight < cpLen(display)) {

--- a/packages/cli/src/ui/hooks/useShellHistory.ts
+++ b/packages/cli/src/ui/hooks/useShellHistory.ts
@@ -137,7 +137,7 @@ export function useShellHistory(projectRoot: string) {
     const newIndex = matchingIndex - 1;
     if (newIndex < 0) {
       setMatchingIndex(-1);
-      return null;
+      return '';
     }
     setMatchingIndex(newIndex);
     return matchingCommands[newIndex] ?? null;

--- a/packages/cli/src/ui/hooks/useShellHistory.ts
+++ b/packages/cli/src/ui/hooks/useShellHistory.ts
@@ -46,6 +46,8 @@ export function useShellHistory(projectRoot: string) {
   const [history, setHistory] = useState<string[]>([]);
   const [historyIndex, setHistoryIndex] = useState(-1);
   const [historyFilePath, setHistoryFilePath] = useState<string | null>(null);
+  const [matchingCommands, setMatchingCommands] = useState<string[]>([]);
+  const [matchingIndex, setMatchingIndex] = useState(-1);
 
   useEffect(() => {
     async function loadHistory() {
@@ -94,10 +96,67 @@ export function useShellHistory(projectRoot: string) {
     return history[newIndex] ?? null;
   }, [history, historyIndex]);
 
+  const getMatchingCommand = useCallback(
+    (toMatch: string) => {
+      const query = toMatch.trim();
+      if (!query) {
+        setMatchingCommands([]);
+        setMatchingIndex(-1);
+        return null;
+      }
+
+      const matches = history.filter((cmd) =>
+        cmd.toLowerCase().includes(query.toLowerCase()),
+      );
+
+      setMatchingCommands(matches);
+      if (matches.length > 0) {
+        setMatchingIndex(0);
+        return matches[0];
+      }
+      setMatchingIndex(-1);
+      return null;
+    },
+    [history],
+  );
+
+  const getPreviousMatchingCommand = useCallback((): string | null => {
+    if (matchingCommands.length === 0) return null;
+    const newIndex =
+      matchingIndex < 0
+        ? 0
+        : Math.min(matchingIndex + 1, matchingCommands.length - 1);
+    setMatchingIndex(newIndex);
+    return matchingCommands[newIndex] ?? null;
+  }, [matchingCommands, matchingIndex]);
+
+  const getNextMatchingCommand = useCallback((): string | null => {
+    if (matchingCommands.length === 0) {
+      return null;
+    }
+    const newIndex = matchingIndex - 1;
+    if (newIndex < 0) {
+      setMatchingIndex(-1);
+      return null;
+    }
+    setMatchingIndex(newIndex);
+    return matchingCommands[newIndex] ?? null;
+  }, [matchingCommands, matchingIndex]);
+
+  const resetMatching = useCallback(() => {
+    setMatchingCommands([]);
+    setMatchingIndex(-1);
+  }, []);
+
   return {
     addCommandToHistory,
     getPreviousCommand,
     getNextCommand,
+    getMatchingCommand,
+    getPreviousMatchingCommand,
+    getNextMatchingCommand,
+    resetMatching,
+
     resetHistoryPosition: () => setHistoryIndex(-1),
   };
 }


### PR DESCRIPTION
## TLDR

Add reverse search mode in shell mode. Search query now appears in green and matched commands in yellow.

## Dive Deeper
Type `Ctrl+r` to enter reverse string search mode when in shell mode. Use up/down to navigate matches.

## Reviewer Test Plan

1.  Enter shell mode with `!`
2.  Press `Ctrl+R` to activate reverse search
3.  Type some characters - they should appear in green
4.  If a match is found, the matched portion should appear in yellow
5.  Test backspace removes characters correctly
6.  Test `Ctrl+G` exits reverse search mode
7.  Test `Enter` accepts the current match

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

#3475