### PR TITLE
feat: Add search capability for shell commands

### DIFF
--- a/packages/cli/src/ui/components/InputPrompt.test.tsx
+++ b/packages/cli/src/ui/components/InputPrompt.test.tsx
@@ -94,6 +94,11 @@ describe('InputPrompt', () => {
       addCommandToHistory: vi.fn(),
       getPreviousCommand: vi.fn().mockReturnValue(null),
       getNextCommand: vi.fn().mockReturnValue(null),
+      getMatchingCommand: vi.fn().mockReturnValue(null),
+      getNextMatchingCommand: vi.fn().mockReturnValue(null),
+      getPreviousMatchingCommand: vi.fn().mockReturnValue(null),
+      resetMatching: vi.fn(),
+
       resetHistoryPosition: vi.fn(),
     };
     mockedUseShellHistory.mockReturnValue(mockShellHistory);
@@ -193,6 +198,40 @@ describe('InputPrompt', () => {
 
     expect(mockShellHistory.addCommandToHistory).toHaveBeenCalledWith('ls -l');
     expect(props.onSubmit).toHaveBeenCalledWith('ls -l');
+    unmount();
+  });
+
+  it('should call reverse search methods on up key when reverse search is active', async () => {
+    props.shellModeActive = true;
+    vi.mocked(mockShellHistory.getPreviousMatchingCommand).mockReturnValue(
+      'ls -l',
+    );
+    const { stdin, unmount } = render(<InputPrompt {...props} />);
+    await wait();
+    // Write Ctrl+R to activate reverse search
+    stdin.write('\u0012'); // Ctrl+R
+    await wait();
+    stdin.write('\u001B[A'); // Up arrow
+    await wait();
+
+    expect(mockShellHistory.getPreviousMatchingCommand).toHaveBeenCalled();
+    expect(props.buffer.setText).toHaveBeenCalledWith('ls -l');
+    unmount();
+  });
+
+  it('should call reverse search methods on down key when reverse search is active', async () => {
+    props.shellModeActive = true;
+    vi.mocked(mockShellHistory.getNextMatchingCommand).mockReturnValue('ls -l');
+    const { stdin, unmount } = render(<InputPrompt {...props} />);
+    await wait();
+    // Write Ctrl+R to activate reverse search
+    stdin.write('\u0012'); // Ctrl+R
+    await wait();
+    stdin.write('\u001B[B'); // Down arrow
+    await wait();
+
+    expect(mockShellHistory.getNextMatchingCommand).toHaveBeenCalled();
+    expect(props.buffer.setText).toHaveBeenCalledWith('ls -l');
     unmount();
   });
 

--- a/packages/cli/src/ui/components/InputPrompt.tsx
+++ b/packages/cli/src/ui/components/InputPrompt.tsx
@@ -52,6 +52,9 @@ export const InputPrompt: React.FC<InputPromptProps> = ({
   setShellModeActive,
 }) => {
   const [justNavigatedHistory, setJustNavigatedHistory] = useState(false);
+  const [reverseSearchActive, setReverseSearchActive] = useState(false);
+  const [reverseSearchQuery, setReverseSearchQuery] = useState('');
+  const [originalBufferText, setOriginalBufferText] = useState('');
 
   const completion = useCompletion(
     buffer.text,
@@ -195,6 +198,13 @@ export const InputPrompt: React.FC<InputPromptProps> = ({
       }
 
       if (key.name === 'escape') {
+        if (reverseSearchActive) {
+          setReverseSearchActive(false);
+          setReverseSearchQuery('');
+          buffer.setText(originalBufferText);
+          shellHistory.resetMatching();
+        }
+
         if (shellModeActive) {
           setShellModeActive(false);
           return;
@@ -261,7 +271,81 @@ export const InputPrompt: React.FC<InputPromptProps> = ({
             return;
           }
         } else {
-          // Shell History Navigation
+          // Shell History Navigation with reverse search
+          if (key.name === 'r' && key.ctrl && !reverseSearchActive) {
+            setReverseSearchActive(true);
+
+            setOriginalBufferText(buffer.text);
+            buffer.setText(''); // Clear the buffer for reverse search
+            setReverseSearchQuery('');
+            return;
+          }
+
+          if (reverseSearchActive) {
+            if (key.name === 'g' && key.ctrl) {
+              setReverseSearchActive(false);
+              shellHistory.resetMatching();
+              setReverseSearchQuery('');
+              buffer.setText(originalBufferText);
+              return;
+            }
+
+            if (key.name === 'up' || (key.name === 'r' && key.ctrl)) {
+              const nextMatch = shellHistory.getPreviousMatchingCommand();
+              if (nextMatch !== null) {
+                buffer.setText(nextMatch);
+              }
+              return;
+            }
+
+            if (key.name === 'down' || (key.name === 's' && key.ctrl)) {
+              const prevMatch = shellHistory.getNextMatchingCommand();
+              const nextText =
+                prevMatch && prevMatch !== '' ? prevMatch : reverseSearchQuery;
+              buffer.setText(nextText);
+              return;
+            }
+
+            if (key.name === 'backspace') {
+              const nextQuery = reverseSearchQuery.slice(0, -1);
+              setReverseSearchQuery(nextQuery);
+              const match = shellHistory.getMatchingCommand(nextQuery);
+              buffer.setText(match || '');
+              return;
+            }
+
+            if (key.name === 'return') {
+              const command = buffer.text;
+
+              setReverseSearchActive(false);
+              setReverseSearchQuery('');
+              shellHistory.resetMatching();
+
+              if (command.trim()) {
+                setOriginalBufferText('');
+                handleSubmitAndClear(command);
+              } else {
+                buffer.setText(originalBufferText);
+              }
+              return;
+            }
+
+            if (
+              key.sequence &&
+              key.sequence.length > 0 &&
+              !key.ctrl &&
+              !key.meta
+            ) {
+              const nextQuery = reverseSearchQuery + key.sequence;
+              setReverseSearchQuery(nextQuery);
+              const match = shellHistory.getMatchingCommand(nextQuery);
+              buffer.setText(match || '');
+              return;
+            }
+            return;
+          }
+
+          // Normal shell history navigation
           if (key.name === 'up') {
             const prevCommand = shellHistory.getPreviousCommand();
             if (prevCommand !== null) buffer.setText(prevCommand);
@@ -329,6 +413,12 @@ export const InputPrompt: React.FC<InputPromptProps> = ({
       handleAutocomplete,
       handleSubmitAndClear,
       shellHistory,
+      reverseSearchActive,
+      reverseSearchQuery,
+      setReverseSearchActive,
+      setReverseSearchQuery,
+      originalBufferText,
+      setOriginalBufferText,
     ],
   );
 
@@ -349,7 +439,15 @@ export const InputPrompt: React.FC<InputPromptProps> = ({
         <Text
           color={shellModeActive ? Colors.AccentYellow : Colors.AccentPurple}
         >
-          {shellModeActive ? '! ' : '> '}
+          {shellModeActive ? (
+            reverseSearchActive ? (
+              <Text color={Colors.AccentCyan}>(r): </Text>
+            ) : (
+              '! '
+            )
+          ) : (
+            '> '
+          )}
         </Text>
         <Box flexGrow={1} flexDirection="column">
           {buffer.text.length === 0 && placeholder ? (
@@ -370,7 +468,10 @@ export const InputPrompt: React.FC<InputPromptProps> = ({
                 display = display + ' '.repeat(inputWidth - currentVisualWidth);
               }
 
-              if (visualIdxInRenderedSet === cursorVisualRow) {
+              if (
+                visualIdxInRenderedSet === cursorVisualRow &&
+                !reverseSearchActive
+              ) {
                 const relativeVisualColForHighlight = cursorVisualColAbsolute;
                 if (relativeVisualColForHighlight >= 0) {
                   if (relativeVisualColForHighlight < cpLen(display)) {
@@ -411,6 +512,9 @@ export const InputPrompt: React.FC<InputPromptProps> = ({
             userInput={buffer.text}
           />
         </Box>
+      )}
+      {reverseSearchActive && shellModeActive && (
+        <Text color={Colors.AccentYellow}>:{reverseSearchQuery}</Text>
       )}
     </>
   );


### PR DESCRIPTION
## TLDR

Add reverse search mode in shell mode. Search query now appears in green and matched commands in yellow.

## Dive Deeper
Type `Ctrl+r` to enter reverse string search mode when in shell mode. Use up/down to navigate matches.

## Reviewer Test Plan

1.  Enter shell mode with `!`
2.  Press `Ctrl+R` to activate reverse search
3.  Type some characters - they should appear in green
4.  If a match is found, the matched portion should appear in yellow
5.  Test backspace removes characters correctly
6.  Test `Ctrl+G` exits reverse search mode
7.  Test `Enter` accepts the current match

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

#3475