### PR TITLE
feat: Better reverse search

### DIFF
--- a/packages/cli/src/ui/components/InputPrompt.test.tsx
+++ b/packages/cli/src/ui/components/InputPrompt.test.tsx
@@ -97,7 +97,12 @@ describe('InputPrompt', () => {
       addCommandToHistory: vi.fn(),
       getPreviousCommand: vi.fn().mockReturnValue(null),
       getNextCommand: vi.fn().mockReturnValue(null),
+      getMatchingCommand: vi.fn().mockReturnValue(null),
+      getNextMatchingCommand: vi.fn().mockReturnValue(null),
+      getPreviousMatchingCommand: vi.fn().mockReturnValue(null),
+      resetMatching: vi.fn(),
       resetHistoryPosition: vi.fn(),
+      history: [],
     };
     mockedUseShellHistory.mockReturnValue(mockShellHistory);
 
@@ -196,28 +201,6 @@ describe('InputPrompt', () => {
 
     expect(mockShellHistory.addCommandToHistory).toHaveBeenCalledWith('ls -l');
     expect(props.onSubmit).toHaveBeenCalledWith('ls -l');
-    unmount();
-  });
-
-  it('should NOT call shell history methods when not in shell mode', async () => {
-    props.buffer.setText('some text');
-    const { stdin, unmount } = render(<InputPrompt {...props} />);
-    await wait();
-
-    stdin.write('\u001B[A'); // Up arrow
-    await wait();
-    stdin.write('\u001B[B'); // Down arrow
-    await wait();
-    stdin.write('\r'); // Enter
-    await wait();
-
-    expect(mockShellHistory.getPreviousCommand).not.toHaveBeenCalled();
-    expect(mockShellHistory.getNextCommand).not.toHaveBeenCalled();
-    expect(mockShellHistory.addCommandToHistory).not.toHaveBeenCalled();
-
-    expect(mockInputHistory.navigateUp).toHaveBeenCalled();
-    expect(mockInputHistory.navigateDown).toHaveBeenCalled();
-    expect(props.onSubmit).toHaveBeenCalledWith('some text');
     unmount();
   });
 
@@ -568,6 +551,69 @@ describe('InputPrompt', () => {
     await wait();
 
     expect(props.buffer.setText).not.toHaveBeenCalled();
+    unmount();
+  });
+
+  describe('reverse shell search', () => {
+    beforeEach(() => {
+      props.shellModeActive = true;
+      mockShellHistory.history = [
+        'git status',
+        'npm install',
+        'git commit -m "test"',
+        'ls -la',
+      ];
+    });
+
+    it('should activate reverse search on Ctrl+R in shell mode', async () => {
+      const { stdin, unmount } = render(<InputPrompt {...props} />);
+      await wait();
+
+      stdin.write('\x12');
+      await wait();
+
+      expect(mockedUseCompletion).toHaveBeenCalledWith(
+        '',
+        '/test/project/src',
+        true,
+        mockSlashCommands,
+        mockCommandContext,
+        expect.any(Object),
+        mockShellHistory.history,
+      );
+      unmount();
+    });
+
+    it('should not activate reverse search on Ctrl+R when not in shell mode', async () => {
+      props.shellModeActive = false;
+      const { stdin, unmount } = render(<InputPrompt {...props} />);
+      await wait();
+
+      stdin.write('\x12');
+      await wait();
+
+      expect(mockedUseCompletion).not.toHaveBeenCalledWith(
+        expect.anything(),
+        expect.anything(),
+        true,
+        expect.anything(),
+        expect.anything(),
+        expect.anything(),
+        mockShellHistory.history,
+      );
+      unmount();
+    });
+  });
+
+  it('should call inputHistory.navigateDown on down arrow in non-shell mode', async () => {
+    props.shellModeActive = false;
+    const { stdin, unmount } = render(<InputPrompt {...props} />);
+    await wait();
+
+    stdin.write('\u001B[B');
+    await wait();
+
+    expect(mockShellHistory.getNextCommand).not.toHaveBeenCalled();
     unmount();
   });
 

--- a/packages/cli/src/ui/hooks/useCompletion.ts
+++ b/packages/cli/src/ui/hooks/useCompletion.ts
@@ -44,6 +44,7 @@ export function useCompletion(
   slashCommands: readonly SlashCommand[],
   commandContext: CommandContext,
   config?: Config,
+  shellHistory?: string[],
 ): UseCompletionReturn {
   const [suggestions, setSuggestions] = useState<Suggestion[]>([]);
   const [activeSuggestionIndex, setActiveSuggestionIndex] =
@@ -125,6 +126,18 @@ export function useCompletion(
   useEffect(() => {
     if (!isActive) {
       resetCompletionState();
+      return;
+    }
+
+    if (shellHistory?.length) {
+      const matches = shellHistory.filter((cmd) =>
+        cmd.toLowerCase().includes(query.toLowerCase()),
+      );
+
+      const matchedHistory = matches.map((s) => ({ label: s, value: s }));
+      setSuggestions(matchedHistory);
+      setShowSuggestions(matchedHistory.length > 0);
+      setActiveSuggestionIndex(matchedHistory.length > 0 ? 0 : -1);
       return;
     }
 
@@ -547,11 +560,12 @@ export function useCompletion(
   }, [
     query,
     cwd,
-    isActive,
     resetCompletionState,
     slashCommands,
     commandContext,
     config,
+    shellHistory,
+    isActive,
   ]);
 
   return {


### PR DESCRIPTION
## TLDR

Add reverse search mode in shell mode. 

## Dive Deeper
Type `Ctrl+r` to enter reverse string search mode when in shell mode. Use up/down to navigate matches.

## Reviewer Test Plan

1.  Enter shell mode with `!`
2.  Press `Ctrl+R` to activate reverse search

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

